### PR TITLE
Fix tests for all Python versions

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -53,11 +53,10 @@ jobs:
         with:
           path: ${{ env.special-working-directory-relative }}
 
-      # Install bundled libs using 3.9 even though you test it on other versions.
-      - name: Use Python 3.9
+      - name: Use Python ${{ matrix.python }}
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: ${{ matrix.python }}
 
       - name: Update pip, install wheel and nox
         run: python -m pip install -U pip wheel nox
@@ -70,13 +69,6 @@ jobs:
           export PYTHONIOENCODING=utf-8
           python -m nox --session install_bundled_libs
         shell: bash
-
-      # Now that the bundle is installed to target using python 3.9
-      # switch back the python we want to test with
-      - name: Use Python ${{ matrix.python }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python }}
 
       # The new python may not have nox so install it again
       - name: Update pip, install wheel and nox (again)

--- a/.github/workflows/push-check.yml
+++ b/.github/workflows/push-check.yml
@@ -58,11 +58,10 @@ jobs:
         with:
           path: ${{ env.special-working-directory-relative }}
 
-      # Install bundled libs using 3.9 even though you test it on other versions.
-      - name: Use Python 3.9
+      - name: Use Python ${{ matrix.python }}
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: ${{ matrix.python }}
 
       - name: Update pip, install wheel and nox
         run: python -m pip install -U pip wheel nox
@@ -75,13 +74,6 @@ jobs:
           export PYTHONIOENCODING=utf-8
           python -m nox --session install_bundled_libs
         shell: bash
-
-      # Now that the bundle is installed to target using python 3.9
-      # switch back the python we want to test with
-      - name: Use Python ${{ matrix.python }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python }}
 
       # The new python may not have nox so install it again
       - name: Update pip, install wheel and nox (again)

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -145,12 +145,12 @@ def _parse_output(content: str) -> list[lsp.Diagnostic]:
     return diagnostics
 
 
-def _get_severity(*_codes: list[str]) -> lsp.DiagnosticSeverity:
-    if _codes[0] == "error":
+def _get_severity(code: str) -> lsp.DiagnosticSeverity:
+    if code == "error":
         return lsp.DiagnosticSeverity.Error
-    if _codes[0] == "warning":
+    if code == "warning":
         return lsp.DiagnosticSeverity.Warning
-    if _codes[0] == "note":
+    if code == "note":
         return lsp.DiagnosticSeverity.Information
 
     return lsp.DiagnosticSeverity.Information
@@ -404,7 +404,7 @@ def _run_tool_on_document(
         #     argv += ["--from-stdin", document.path]
         # Read up on how your tool handles contents via stdin. If stdin is not supported use
         # set use_stdin to False, or provide path, what ever is appropriate for your tool.
-        argv += []
+        argv += ["-"]
     else:
         argv += [document.path]
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -100,7 +100,7 @@ def _setup_template_environment(session: nox.Session) -> None:
     _install_bundle(session)
 
 
-@nox.session(python="3.9")
+@nox.session()
 def install_bundled_libs(session):
     """Installs the libraries that will be bundled with the extension."""
     session.install("wheel")


### PR DESCRIPTION
Previously only Python 3.9 test was passing. This change makes it so tree-sitter has bindings for all Python versions via the install bundles of nox.