### PR TITLE
Allow precaution to run against multiple languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     },
     "keywords": [
         "python",
+        "linting",
+        "formatting",
         "precaution"
     ],
     "engines": {
@@ -45,7 +47,11 @@
         }
     },
     "activationEvents": [
+        "onLanguage:go",
+        "onLanguage:java",
         "onLanguage:python",
+        "workspaceContains:*.go",
+        "workspaceContains:*.java",
         "workspaceContains:*.py"
     ],
     "main": "./dist/extension.js",


### PR DESCRIPTION
This allows precaution to run on Go, Java, and Python files.