### PR TITLE
Remove highlighting in extension description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "precaution",
     "displayName": "Precaution",
-    "description": "Linting support for files using `Precaution`.",
+    "description": "Linting support for files using Precaution.",
     "version": "2025.3.1",
     "preview": true,
     "serverInfo": {


### PR DESCRIPTION
The VSCode marketplace doesn't render it anyway.